### PR TITLE
Remove base from context

### DIFF
--- a/server/handler/eval_context.go
+++ b/server/handler/eval_context.go
@@ -183,9 +183,16 @@ func (ec *EvalContext) PostStatus(ctx context.Context, state, message string) {
 	publicURL := strings.TrimSuffix(ec.PublicURL, "/")
 	detailsURL := fmt.Sprintf("%s/details/%s/%s/%d", publicURL, owner, repo, ec.PullContext.Number())
 
+	var context string
+	if !ec.Options.StatusCheckContextIgnoreBase {
+		context = fmt.Sprintf("%s: %s", ec.Options.StatusCheckContext, base)
+	} else {
+		context = ec.Options.StatusCheckContext
+	}
+
 	status := github.RepoStatus{
 		State:       &state,
-		Context:     github.Ptr(fmt.Sprintf("%s: %s", ec.Options.StatusCheckContext, base)),
+		Context:     github.Ptr(context),
 		Description: &message,
 		TargetURL:   &detailsURL,
 	}

--- a/server/handler/eval_options.go
+++ b/server/handler/eval_options.go
@@ -39,6 +39,10 @@ type PullEvaluationOptions struct {
 	// pattern: <StatusCheckContext>: <Base Branch Name>
 	StatusCheckContext string `yaml:"status_check_context"`
 
+	// StatusCheckContextIgnoreBase will ignore the base branch name when creating the status context.
+	// pattern: <StatusCheckContext>
+	StatusCheckContextIgnoreBase bool `yaml:"status_check_context_ignore_base"`
+
 	// ExpandRequiredReviewers enables a UI feature where the details page
 	// shows a list of the users who can approve each rule. Enabling this
 	// feature can leak information about team membership and permissions that


### PR DESCRIPTION
## What

Remove base from context

## Why

Set the same required status check across org