### PR TITLE
Optimize actors

### DIFF
--- a/policy/common/actor.go
+++ b/policy/common/actor.go
@@ -126,18 +126,22 @@ func (a *Actors) IsActor(ctx context.Context, prctx pull.Context, user string) (
 		}
 	}
 
-	userPerm, err := prctx.CollaboratorPermission(user)
-	if err != nil {
-		return false, err
-	}
-	if userPerm == pull.PermissionNone {
-		return false, nil
-	}
+	permissions := a.GetPermissions()
+	if len(permissions) > 0 {
+		userPerm, err := prctx.CollaboratorPermission(user)
+		if err != nil {
+			return false, err
+		}
+		if userPerm == pull.PermissionNone {
+			return false, nil
+		}
 
-	for _, p := range a.GetPermissions() {
-		if userPerm >= p {
-			return true, nil
+		for _, p := range permissions {
+			if userPerm >= p {
+				return true, nil
+			}
 		}
 	}
+
 	return false, nil
 }


### PR DESCRIPTION
## What

Don't call `CollaboratorPermission` unless needed

## Why

To save GraphQL rate limit