### PR TITLE
[For upstream] Implement custom properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,6 +471,46 @@ if:
   has_valid_signatures_by_keys:
     key_ids: ["3AA5C34371567BD2"]
 
+  # "custom_property_is_not_null" is satisfied if all of the specified repository
+  # custom properties are set to a non-empty string or array on the target repository.
+  custom_property_is_not_null:
+    - "release_tier"
+    - "service_owner"
+
+  # "custom_property_is_null" is satisfied if all of the specified repository
+  # custom properties are unset or set to an empty string or array on the
+  # target repository.
+  custom_property_is_null:
+    - "deprecated_since"
+
+  # "custom_property_matches_any_of" is satisfied if, for each property key in
+  # the map, the repository custom property exists and its string value matches
+  # at least one of the provided regular expressions. 
+  #
+  # Regex matching only applies to string typed (including boolean) custom properties.
+  # Array-type properties are not matched and will cause the predicate to fail
+  # for that key. Unset/null properties will also fail the match.
+  #
+  # Note: Double-quote strings must escape backslashes while single/plain do not.
+  # See the Notes on YAML Syntax section of this README for more information.
+  custom_property_matches_any_of:
+    environment: ["^prod$", "^staging$"]
+    service_tier: ["^(critical|high)$"]
+
+  # "custom_property_matches_none_of" is satisfied if, for each property key in
+  # the map, the repository custom property does not exist, its string value matches
+  # none of the provided regular expressions.
+  #
+  # Regex matching only applies to string typed (including boolean) custom properties.
+  # Array-type properties are not matched and will cause the predicate to always pass
+  # for that key. Unset/null properties will also pass the match.
+  #
+  # Note: Double-quote strings must escape backslashes while single/plain do not.
+  # See the Notes on YAML Syntax section of this README for more information.
+  custom_property_matches_none_of:
+    environment: ["^dev$", "^test$"]
+    service_tier: ["^low$"]
+
 # "options" specifies a set of restrictions on approvals. If the block does not
 # exist, the default values are used.
 options:

--- a/policy/predicate/custom_properties.go
+++ b/policy/predicate/custom_properties.go
@@ -1,0 +1,194 @@
+// Copyright 2025 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package predicate
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"slices"
+	"strings"
+
+	"github.com/palantir/policy-bot/policy/common"
+	"github.com/palantir/policy-bot/pull"
+	"github.com/pkg/errors"
+)
+
+type CustomPropertyIsNull []string
+type CustomPropertyIsNotNull []string
+type CustomPropertyMatchesAnyOf map[string][]string
+type CustomPropertyMatchesNoneOf map[string][]string
+
+var _ Predicate = (CustomPropertyIsNull)(nil)
+var _ Predicate = (CustomPropertyIsNotNull)(nil)
+var _ Predicate = (CustomPropertyMatchesAnyOf)(nil)
+var _ Predicate = (CustomPropertyMatchesNoneOf)(nil)
+
+func formatCustomProperties(customProperties map[string]pull.CustomProperty) []string {
+	result := []string{}
+	keys := make([]string, 0, len(customProperties))
+	for k := range customProperties {
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
+	for _, k := range keys {
+		v := customProperties[k]
+		formatted := "(null)"
+		if v.String != nil {
+			formatted = *v.String
+		}
+		if v.Array != nil {
+			formatted = "[" + strings.Join(v.Array, ", ") + "]"
+		}
+		result = append(result, fmt.Sprintf("%s: %s", k, formatted))
+	}
+	return result
+}
+
+func (pred CustomPropertyIsNotNull) Evaluate(ctx context.Context, prctx pull.Context) (*common.PredicateResult, error) {
+	customProperties, err := prctx.RepositoryCustomProperties()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get repository custom properties")
+	}
+
+	predicateResult := common.PredicateResult{
+		ValuePhrase:     "specified custom properties",
+		Values:          formatCustomProperties(customProperties),
+		ConditionPhrase: "have a non-null value",
+		ConditionValues: pred,
+		Satisfied:       true,
+	}
+
+	for _, property := range pred {
+		if _, ok := customProperties[property]; !ok {
+			predicateResult.Satisfied = false
+			return &predicateResult, nil
+		}
+	}
+
+	return &predicateResult, nil
+}
+
+func (pred CustomPropertyIsNull) Evaluate(ctx context.Context, prctx pull.Context) (*common.PredicateResult, error) {
+	customProperties, err := prctx.RepositoryCustomProperties()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get repository custom properties")
+	}
+
+	predicateResult := common.PredicateResult{
+		ValuePhrase:       "specified custom properties",
+		Values:            formatCustomProperties(customProperties),
+		ReverseSkipPhrase: true,
+		ConditionPhrase:   "have a non-null value",
+		ConditionValues:   pred,
+		Satisfied:         true,
+	}
+
+	for _, property := range pred {
+		if _, ok := customProperties[property]; ok {
+			predicateResult.Satisfied = false
+			return &predicateResult, nil
+		}
+	}
+
+	return &predicateResult, nil
+}
+
+func (pred CustomPropertyMatchesAnyOf) Evaluate(ctx context.Context, prctx pull.Context) (*common.PredicateResult, error) {
+	customProperties, err := prctx.RepositoryCustomProperties()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get repository custom properties")
+	}
+
+	predicateResult := common.PredicateResult{
+		ValuePhrase:     "specified custom properties",
+		Values:          formatCustomProperties(customProperties),
+		ConditionPhrase: "match one or more of the specified values",
+		ConditionsMap:   pred,
+		Satisfied:       true,
+	}
+
+	for property, allowedValues := range pred {
+		propValue, ok := customProperties[property]
+		if !ok {
+			predicateResult.Satisfied = false
+			return &predicateResult, nil
+		}
+
+		matched := false
+		if propValue.String != nil {
+			for _, v := range allowedValues {
+				re, err := regexp.Compile(v)
+				if err != nil {
+					return nil, errors.Wrapf(err, "failed to compile regex %v for custom property %s", v, property)
+				}
+				if re.MatchString(*propValue.String) {
+					matched = true
+					break
+				}
+			}
+		}
+
+		if !matched {
+			predicateResult.Satisfied = false
+			return &predicateResult, nil
+		}
+	}
+
+	return &predicateResult, nil
+}
+
+func (pred CustomPropertyMatchesNoneOf) Evaluate(ctx context.Context, prctx pull.Context) (*common.PredicateResult, error) {
+	customProperties, err := prctx.RepositoryCustomProperties()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get repository custom properties")
+	}
+
+	predicateResult := common.PredicateResult{
+		ValuePhrase:       "specified custom properties",
+		Values:            formatCustomProperties(customProperties),
+		ReverseSkipPhrase: true,
+		ConditionPhrase:   "match one or more of the specified values",
+		ConditionsMap:     pred,
+		Satisfied:         true,
+	}
+
+	for property, disallowedValues := range pred {
+		propValue, ok := customProperties[property]
+		if !ok {
+			continue
+		}
+
+		if propValue.String != nil {
+			for _, v := range disallowedValues {
+				re, err := regexp.Compile(v)
+				if err != nil {
+					return nil, errors.Wrapf(err, "failed to compile regex %v for custom property %s", v, property)
+				}
+				if re.MatchString(*propValue.String) {
+					predicateResult.Satisfied = false
+					return &predicateResult, nil
+				}
+			}
+		}
+	}
+
+	return &predicateResult, nil
+}
+
+func (pred CustomPropertyIsNotNull) Trigger() common.Trigger     { return common.TriggerStatic }
+func (pred CustomPropertyIsNull) Trigger() common.Trigger        { return common.TriggerStatic }
+func (pred CustomPropertyMatchesAnyOf) Trigger() common.Trigger  { return common.TriggerStatic }
+func (pred CustomPropertyMatchesNoneOf) Trigger() common.Trigger { return common.TriggerStatic }

--- a/policy/predicate/custom_properties.go
+++ b/policy/predicate/custom_properties.go
@@ -17,7 +17,6 @@ package predicate
 import (
 	"context"
 	"fmt"
-	"regexp"
 	"slices"
 	"strings"
 
@@ -28,8 +27,8 @@ import (
 
 type CustomPropertyIsNull []string
 type CustomPropertyIsNotNull []string
-type CustomPropertyMatchesAnyOf map[string][]string
-type CustomPropertyMatchesNoneOf map[string][]string
+type CustomPropertyMatchesAnyOf map[string][]common.Regexp
+type CustomPropertyMatchesNoneOf map[string][]common.Regexp
 
 var _ Predicate = (CustomPropertyIsNull)(nil)
 var _ Predicate = (CustomPropertyIsNotNull)(nil)
@@ -112,11 +111,20 @@ func (pred CustomPropertyMatchesAnyOf) Evaluate(ctx context.Context, prctx pull.
 		return nil, errors.Wrap(err, "failed to get repository custom properties")
 	}
 
+	conditionsMap := make(map[string][]string, len(pred))
+	for property, allowedValues := range pred {
+		strValues := make([]string, len(allowedValues))
+		for i, v := range allowedValues {
+			strValues[i] = v.String()
+		}
+		conditionsMap[property] = strValues
+	}
+
 	predicateResult := common.PredicateResult{
 		ValuePhrase:     "specified custom properties",
 		Values:          formatCustomProperties(customProperties),
 		ConditionPhrase: "match one or more of the specified values",
-		ConditionsMap:   pred,
+		ConditionsMap:   conditionsMap,
 		Satisfied:       true,
 	}
 
@@ -130,11 +138,7 @@ func (pred CustomPropertyMatchesAnyOf) Evaluate(ctx context.Context, prctx pull.
 		matched := false
 		if propValue.String != nil {
 			for _, v := range allowedValues {
-				re, err := regexp.Compile(v)
-				if err != nil {
-					return nil, errors.Wrapf(err, "failed to compile regex %v for custom property %s", v, property)
-				}
-				if re.MatchString(*propValue.String) {
+				if v.Matches(*propValue.String) {
 					matched = true
 					break
 				}
@@ -156,12 +160,21 @@ func (pred CustomPropertyMatchesNoneOf) Evaluate(ctx context.Context, prctx pull
 		return nil, errors.Wrap(err, "failed to get repository custom properties")
 	}
 
+	conditionsMap := make(map[string][]string, len(pred))
+	for property, allowedValues := range pred {
+		strValues := make([]string, len(allowedValues))
+		for i, v := range allowedValues {
+			strValues[i] = v.String()
+		}
+		conditionsMap[property] = strValues
+	}
+
 	predicateResult := common.PredicateResult{
 		ValuePhrase:       "specified custom properties",
 		Values:            formatCustomProperties(customProperties),
 		ReverseSkipPhrase: true,
 		ConditionPhrase:   "match one or more of the specified values",
-		ConditionsMap:     pred,
+		ConditionsMap:     conditionsMap,
 		Satisfied:         true,
 	}
 
@@ -173,11 +186,7 @@ func (pred CustomPropertyMatchesNoneOf) Evaluate(ctx context.Context, prctx pull
 
 		if propValue.String != nil {
 			for _, v := range disallowedValues {
-				re, err := regexp.Compile(v)
-				if err != nil {
-					return nil, errors.Wrapf(err, "failed to compile regex %v for custom property %s", v, property)
-				}
-				if re.MatchString(*propValue.String) {
+				if v.Matches(*propValue.String) {
 					predicateResult.Satisfied = false
 					return &predicateResult, nil
 				}

--- a/policy/predicate/custom_properties.go
+++ b/policy/predicate/custom_properties.go
@@ -135,17 +135,7 @@ func (pred CustomPropertyMatchesAnyOf) Evaluate(ctx context.Context, prctx pull.
 			return &predicateResult, nil
 		}
 
-		matched := false
-		if propValue.String != nil {
-			for _, v := range allowedValues {
-				if v.Matches(*propValue.String) {
-					matched = true
-					break
-				}
-			}
-		}
-
-		if !matched {
+		if propValue.String == nil || !anyMatches(allowedValues, *propValue.String) {
 			predicateResult.Satisfied = false
 			return &predicateResult, nil
 		}
@@ -184,13 +174,9 @@ func (pred CustomPropertyMatchesNoneOf) Evaluate(ctx context.Context, prctx pull
 			continue
 		}
 
-		if propValue.String != nil {
-			for _, v := range disallowedValues {
-				if v.Matches(*propValue.String) {
-					predicateResult.Satisfied = false
-					return &predicateResult, nil
-				}
-			}
+		if propValue.String != nil && anyMatches(disallowedValues, *propValue.String) {
+			predicateResult.Satisfied = false
+			return &predicateResult, nil
 		}
 	}
 

--- a/policy/predicate/custom_properties_test.go
+++ b/policy/predicate/custom_properties_test.go
@@ -146,7 +146,7 @@ func TestCustomPropertiesMatchesAnyOf(t *testing.T) {
 	runCustomPropertyTestCase(t, customPropertiesTestCtx, []customPropertyTestCase{
 		{
 			description: "property matches regex",
-			predicate:   CustomPropertyMatchesAnyOf(mustCompileRegexpMap(map[string][]string{"custom1": []string{`.*`}})),
+			predicate:   CustomPropertyMatchesAnyOf(mustCompileRegexpMap(map[string][]string{"custom1": {`.*`}})),
 			ExpectedPredicateResult: &common.PredicateResult{
 				Satisfied:     true,
 				Values:        defaultTestCustomPropertiesValues,
@@ -155,7 +155,7 @@ func TestCustomPropertiesMatchesAnyOf(t *testing.T) {
 		},
 		{
 			description: "property does not match regex",
-			predicate:   CustomPropertyMatchesAnyOf(mustCompileRegexpMap(map[string][]string{"custom1": []string{`nomatch`}})),
+			predicate:   CustomPropertyMatchesAnyOf(mustCompileRegexpMap(map[string][]string{"custom1": {`nomatch`}})),
 			ExpectedPredicateResult: &common.PredicateResult{
 				Satisfied:     false,
 				Values:        defaultTestCustomPropertiesValues,
@@ -164,7 +164,7 @@ func TestCustomPropertiesMatchesAnyOf(t *testing.T) {
 		},
 		{
 			description: "multiple regexes and one matches",
-			predicate:   CustomPropertyMatchesAnyOf(mustCompileRegexpMap(map[string][]string{"custom1": []string{`nomatch`, `value1`}})),
+			predicate:   CustomPropertyMatchesAnyOf(mustCompileRegexpMap(map[string][]string{"custom1": {`nomatch`, `value1`}})),
 			ExpectedPredicateResult: &common.PredicateResult{
 				Satisfied:     true,
 				Values:        defaultTestCustomPropertiesValues,
@@ -173,7 +173,7 @@ func TestCustomPropertiesMatchesAnyOf(t *testing.T) {
 		},
 		{
 			description: "multiple regexes and none match",
-			predicate:   CustomPropertyMatchesAnyOf(mustCompileRegexpMap(map[string][]string{"custom1": []string{`nomatch`, `alsonomatch`}})),
+			predicate:   CustomPropertyMatchesAnyOf(mustCompileRegexpMap(map[string][]string{"custom1": {`nomatch`, `alsonomatch`}})),
 			ExpectedPredicateResult: &common.PredicateResult{
 				Satisfied:     false,
 				Values:        defaultTestCustomPropertiesValues,
@@ -182,7 +182,7 @@ func TestCustomPropertiesMatchesAnyOf(t *testing.T) {
 		},
 		{
 			description: "multiple properties and one matches",
-			predicate:   CustomPropertyMatchesAnyOf(mustCompileRegexpMap(map[string][]string{"custom1": []string{`nomatch`}, "custom2": []string{`value2`}})),
+			predicate:   CustomPropertyMatchesAnyOf(mustCompileRegexpMap(map[string][]string{"custom1": {`nomatch`}, "custom2": {`value2`}})),
 			ExpectedPredicateResult: &common.PredicateResult{
 				Satisfied:     false,
 				Values:        defaultTestCustomPropertiesValues,
@@ -191,7 +191,7 @@ func TestCustomPropertiesMatchesAnyOf(t *testing.T) {
 		},
 		{
 			description: "multiple properties and none match",
-			predicate:   CustomPropertyMatchesAnyOf(mustCompileRegexpMap(map[string][]string{"custom1": []string{`nomatch`}, "custom2": []string{`alsonomatch`}})),
+			predicate:   CustomPropertyMatchesAnyOf(mustCompileRegexpMap(map[string][]string{"custom1": {`nomatch`}, "custom2": {`alsonomatch`}})),
 			ExpectedPredicateResult: &common.PredicateResult{
 				Satisfied:     false,
 				Values:        defaultTestCustomPropertiesValues,
@@ -200,7 +200,7 @@ func TestCustomPropertiesMatchesAnyOf(t *testing.T) {
 		},
 		{
 			description: "array should never match",
-			predicate:   CustomPropertyMatchesAnyOf(mustCompileRegexpMap(map[string][]string{"custom3": []string{`.*`}})),
+			predicate:   CustomPropertyMatchesAnyOf(mustCompileRegexpMap(map[string][]string{"custom3": {`.*`}})),
 			ExpectedPredicateResult: &common.PredicateResult{
 				Satisfied:     false,
 				Values:        defaultTestCustomPropertiesValues,
@@ -223,7 +223,7 @@ func TestCustomPropertiesMatchesNoneOf(t *testing.T) {
 	runCustomPropertyTestCase(t, customPropertiesTestCtx, []customPropertyTestCase{
 		{
 			description: "property matches regex",
-			predicate:   CustomPropertyMatchesNoneOf(mustCompileRegexpMap(map[string][]string{"custom1": []string{`.*`}})),
+			predicate:   CustomPropertyMatchesNoneOf(mustCompileRegexpMap(map[string][]string{"custom1": {`.*`}})),
 			ExpectedPredicateResult: &common.PredicateResult{
 				Satisfied:     false,
 				Values:        defaultTestCustomPropertiesValues,
@@ -232,7 +232,7 @@ func TestCustomPropertiesMatchesNoneOf(t *testing.T) {
 		},
 		{
 			description: "property does not match regex",
-			predicate:   CustomPropertyMatchesNoneOf(mustCompileRegexpMap(map[string][]string{"custom1": []string{`nomatch`}})),
+			predicate:   CustomPropertyMatchesNoneOf(mustCompileRegexpMap(map[string][]string{"custom1": {`nomatch`}})),
 			ExpectedPredicateResult: &common.PredicateResult{
 				Satisfied:     true,
 				Values:        defaultTestCustomPropertiesValues,
@@ -241,7 +241,7 @@ func TestCustomPropertiesMatchesNoneOf(t *testing.T) {
 		},
 		{
 			description: "multiple regexes and one matches",
-			predicate:   CustomPropertyMatchesNoneOf(mustCompileRegexpMap(map[string][]string{"custom1": []string{`nomatch`, `value1`}})),
+			predicate:   CustomPropertyMatchesNoneOf(mustCompileRegexpMap(map[string][]string{"custom1": {`nomatch`, `value1`}})),
 			ExpectedPredicateResult: &common.PredicateResult{
 				Satisfied:     false,
 				Values:        defaultTestCustomPropertiesValues,
@@ -250,7 +250,7 @@ func TestCustomPropertiesMatchesNoneOf(t *testing.T) {
 		},
 		{
 			description: "multiple regexes and none match",
-			predicate:   CustomPropertyMatchesNoneOf(mustCompileRegexpMap(map[string][]string{"custom1": []string{`nomatch`, `alsonomatch`}})),
+			predicate:   CustomPropertyMatchesNoneOf(mustCompileRegexpMap(map[string][]string{"custom1": {`nomatch`, `alsonomatch`}})),
 			ExpectedPredicateResult: &common.PredicateResult{
 				Satisfied:     true,
 				Values:        defaultTestCustomPropertiesValues,
@@ -259,7 +259,7 @@ func TestCustomPropertiesMatchesNoneOf(t *testing.T) {
 		},
 		{
 			description: "multiple properties and one matches",
-			predicate:   CustomPropertyMatchesNoneOf(mustCompileRegexpMap(map[string][]string{"custom1": []string{`nomatch`}, "custom2": []string{`value2`}})),
+			predicate:   CustomPropertyMatchesNoneOf(mustCompileRegexpMap(map[string][]string{"custom1": {`nomatch`}, "custom2": {`value2`}})),
 			ExpectedPredicateResult: &common.PredicateResult{
 				Satisfied:     false,
 				Values:        defaultTestCustomPropertiesValues,
@@ -268,7 +268,7 @@ func TestCustomPropertiesMatchesNoneOf(t *testing.T) {
 		},
 		{
 			description: "multiple properties and none match",
-			predicate:   CustomPropertyMatchesNoneOf(mustCompileRegexpMap(map[string][]string{"custom1": []string{`nomatch`}, "custom2": []string{`alsonomatch`}})),
+			predicate:   CustomPropertyMatchesNoneOf(mustCompileRegexpMap(map[string][]string{"custom1": {`nomatch`}, "custom2": {`alsonomatch`}})),
 			ExpectedPredicateResult: &common.PredicateResult{
 				Satisfied:     true,
 				Values:        defaultTestCustomPropertiesValues,
@@ -277,7 +277,7 @@ func TestCustomPropertiesMatchesNoneOf(t *testing.T) {
 		},
 		{
 			description: "array should never match",
-			predicate:   CustomPropertyMatchesNoneOf(mustCompileRegexpMap(map[string][]string{"custom3": []string{`.*`}})),
+			predicate:   CustomPropertyMatchesNoneOf(mustCompileRegexpMap(map[string][]string{"custom3": {`.*`}})),
 			ExpectedPredicateResult: &common.PredicateResult{
 				Satisfied:     true,
 				Values:        defaultTestCustomPropertiesValues,

--- a/policy/predicate/custom_properties_test.go
+++ b/policy/predicate/custom_properties_test.go
@@ -146,7 +146,7 @@ func TestCustomPropertiesMatchesAnyOf(t *testing.T) {
 	runCustomPropertyTestCase(t, customPropertiesTestCtx, []customPropertyTestCase{
 		{
 			description: "property matches regex",
-			predicate:   CustomPropertyMatchesAnyOf{"custom1": []string{`.*`}},
+			predicate:   CustomPropertyMatchesAnyOf(mustCompileRegexpMap(map[string][]string{"custom1": []string{`.*`}})),
 			ExpectedPredicateResult: &common.PredicateResult{
 				Satisfied:     true,
 				Values:        defaultTestCustomPropertiesValues,
@@ -155,7 +155,7 @@ func TestCustomPropertiesMatchesAnyOf(t *testing.T) {
 		},
 		{
 			description: "property does not match regex",
-			predicate:   CustomPropertyMatchesAnyOf{"custom1": []string{`nomatch`}},
+			predicate:   CustomPropertyMatchesAnyOf(mustCompileRegexpMap(map[string][]string{"custom1": []string{`nomatch`}})),
 			ExpectedPredicateResult: &common.PredicateResult{
 				Satisfied:     false,
 				Values:        defaultTestCustomPropertiesValues,
@@ -164,7 +164,7 @@ func TestCustomPropertiesMatchesAnyOf(t *testing.T) {
 		},
 		{
 			description: "multiple regexes and one matches",
-			predicate:   CustomPropertyMatchesAnyOf{"custom1": []string{`nomatch`, `value1`}},
+			predicate:   CustomPropertyMatchesAnyOf(mustCompileRegexpMap(map[string][]string{"custom1": []string{`nomatch`, `value1`}})),
 			ExpectedPredicateResult: &common.PredicateResult{
 				Satisfied:     true,
 				Values:        defaultTestCustomPropertiesValues,
@@ -173,7 +173,7 @@ func TestCustomPropertiesMatchesAnyOf(t *testing.T) {
 		},
 		{
 			description: "multiple regexes and none match",
-			predicate:   CustomPropertyMatchesAnyOf{"custom1": []string{`nomatch`, `alsonomatch`}},
+			predicate:   CustomPropertyMatchesAnyOf(mustCompileRegexpMap(map[string][]string{"custom1": []string{`nomatch`, `alsonomatch`}})),
 			ExpectedPredicateResult: &common.PredicateResult{
 				Satisfied:     false,
 				Values:        defaultTestCustomPropertiesValues,
@@ -182,7 +182,7 @@ func TestCustomPropertiesMatchesAnyOf(t *testing.T) {
 		},
 		{
 			description: "multiple properties and one matches",
-			predicate:   CustomPropertyMatchesAnyOf{"custom1": []string{`nomatch`}, "custom2": []string{`value2`}},
+			predicate:   CustomPropertyMatchesAnyOf(mustCompileRegexpMap(map[string][]string{"custom1": []string{`nomatch`}, "custom2": []string{`value2`}})),
 			ExpectedPredicateResult: &common.PredicateResult{
 				Satisfied:     false,
 				Values:        defaultTestCustomPropertiesValues,
@@ -191,7 +191,7 @@ func TestCustomPropertiesMatchesAnyOf(t *testing.T) {
 		},
 		{
 			description: "multiple properties and none match",
-			predicate:   CustomPropertyMatchesAnyOf{"custom1": []string{`nomatch`}, "custom2": []string{`alsonomatch`}},
+			predicate:   CustomPropertyMatchesAnyOf(mustCompileRegexpMap(map[string][]string{"custom1": []string{`nomatch`}, "custom2": []string{`alsonomatch`}})),
 			ExpectedPredicateResult: &common.PredicateResult{
 				Satisfied:     false,
 				Values:        defaultTestCustomPropertiesValues,
@@ -200,7 +200,7 @@ func TestCustomPropertiesMatchesAnyOf(t *testing.T) {
 		},
 		{
 			description: "array should never match",
-			predicate:   CustomPropertyMatchesAnyOf{"custom3": []string{`.*`}},
+			predicate:   CustomPropertyMatchesAnyOf(mustCompileRegexpMap(map[string][]string{"custom3": []string{`.*`}})),
 			ExpectedPredicateResult: &common.PredicateResult{
 				Satisfied:     false,
 				Values:        defaultTestCustomPropertiesValues,
@@ -208,15 +208,8 @@ func TestCustomPropertiesMatchesAnyOf(t *testing.T) {
 			},
 		},
 		{
-			description: "invalid regex should err",
-			predicate:   CustomPropertyMatchesAnyOf{"custom1": []string{`*`}},
-			ExpectedErr: func(err error) bool {
-				return err.Error() == "failed to compile regex * for custom property custom1: error parsing regexp: missing argument to repetition operator: `*`"
-			},
-		},
-		{
 			description: "no properties are checked",
-			predicate:   CustomPropertyMatchesAnyOf{},
+			predicate:   CustomPropertyMatchesAnyOf(mustCompileRegexpMap(map[string][]string{})),
 			ExpectedPredicateResult: &common.PredicateResult{
 				Satisfied:     true,
 				Values:        defaultTestCustomPropertiesValues,
@@ -230,7 +223,7 @@ func TestCustomPropertiesMatchesNoneOf(t *testing.T) {
 	runCustomPropertyTestCase(t, customPropertiesTestCtx, []customPropertyTestCase{
 		{
 			description: "property matches regex",
-			predicate:   CustomPropertyMatchesNoneOf{"custom1": []string{`.*`}},
+			predicate:   CustomPropertyMatchesNoneOf(mustCompileRegexpMap(map[string][]string{"custom1": []string{`.*`}})),
 			ExpectedPredicateResult: &common.PredicateResult{
 				Satisfied:     false,
 				Values:        defaultTestCustomPropertiesValues,
@@ -239,7 +232,7 @@ func TestCustomPropertiesMatchesNoneOf(t *testing.T) {
 		},
 		{
 			description: "property does not match regex",
-			predicate:   CustomPropertyMatchesNoneOf{"custom1": []string{`nomatch`}},
+			predicate:   CustomPropertyMatchesNoneOf(mustCompileRegexpMap(map[string][]string{"custom1": []string{`nomatch`}})),
 			ExpectedPredicateResult: &common.PredicateResult{
 				Satisfied:     true,
 				Values:        defaultTestCustomPropertiesValues,
@@ -248,7 +241,7 @@ func TestCustomPropertiesMatchesNoneOf(t *testing.T) {
 		},
 		{
 			description: "multiple regexes and one matches",
-			predicate:   CustomPropertyMatchesNoneOf{"custom1": []string{`nomatch`, `value1`}},
+			predicate:   CustomPropertyMatchesNoneOf(mustCompileRegexpMap(map[string][]string{"custom1": []string{`nomatch`, `value1`}})),
 			ExpectedPredicateResult: &common.PredicateResult{
 				Satisfied:     false,
 				Values:        defaultTestCustomPropertiesValues,
@@ -257,7 +250,7 @@ func TestCustomPropertiesMatchesNoneOf(t *testing.T) {
 		},
 		{
 			description: "multiple regexes and none match",
-			predicate:   CustomPropertyMatchesNoneOf{"custom1": []string{`nomatch`, `alsonomatch`}},
+			predicate:   CustomPropertyMatchesNoneOf(mustCompileRegexpMap(map[string][]string{"custom1": []string{`nomatch`, `alsonomatch`}})),
 			ExpectedPredicateResult: &common.PredicateResult{
 				Satisfied:     true,
 				Values:        defaultTestCustomPropertiesValues,
@@ -266,7 +259,7 @@ func TestCustomPropertiesMatchesNoneOf(t *testing.T) {
 		},
 		{
 			description: "multiple properties and one matches",
-			predicate:   CustomPropertyMatchesNoneOf{"custom1": []string{`nomatch`}, "custom2": []string{`value2`}},
+			predicate:   CustomPropertyMatchesNoneOf(mustCompileRegexpMap(map[string][]string{"custom1": []string{`nomatch`}, "custom2": []string{`value2`}})),
 			ExpectedPredicateResult: &common.PredicateResult{
 				Satisfied:     false,
 				Values:        defaultTestCustomPropertiesValues,
@@ -275,7 +268,7 @@ func TestCustomPropertiesMatchesNoneOf(t *testing.T) {
 		},
 		{
 			description: "multiple properties and none match",
-			predicate:   CustomPropertyMatchesNoneOf{"custom1": []string{`nomatch`}, "custom2": []string{`alsonomatch`}},
+			predicate:   CustomPropertyMatchesNoneOf(mustCompileRegexpMap(map[string][]string{"custom1": []string{`nomatch`}, "custom2": []string{`alsonomatch`}})),
 			ExpectedPredicateResult: &common.PredicateResult{
 				Satisfied:     true,
 				Values:        defaultTestCustomPropertiesValues,
@@ -284,7 +277,7 @@ func TestCustomPropertiesMatchesNoneOf(t *testing.T) {
 		},
 		{
 			description: "array should never match",
-			predicate:   CustomPropertyMatchesNoneOf{"custom3": []string{`.*`}},
+			predicate:   CustomPropertyMatchesNoneOf(mustCompileRegexpMap(map[string][]string{"custom3": []string{`.*`}})),
 			ExpectedPredicateResult: &common.PredicateResult{
 				Satisfied:     true,
 				Values:        defaultTestCustomPropertiesValues,
@@ -292,15 +285,8 @@ func TestCustomPropertiesMatchesNoneOf(t *testing.T) {
 			},
 		},
 		{
-			description: "invalid regex should err",
-			predicate:   CustomPropertyMatchesNoneOf{"custom1": []string{`*`}},
-			ExpectedErr: func(err error) bool {
-				return err.Error() == "failed to compile regex * for custom property custom1: error parsing regexp: missing argument to repetition operator: `*`"
-			},
-		},
-		{
 			description: "no properties are checked",
-			predicate:   CustomPropertyMatchesNoneOf{},
+			predicate:   CustomPropertyMatchesNoneOf(mustCompileRegexpMap(map[string][]string{})),
 			ExpectedPredicateResult: &common.PredicateResult{
 				Satisfied:     true,
 				Values:        defaultTestCustomPropertiesValues,
@@ -315,6 +301,22 @@ type customPropertyTestCase struct {
 	predicate               Predicate
 	ExpectedPredicateResult *common.PredicateResult
 	ExpectedErr             func(error) bool
+}
+
+func mustCompileRegexpMap(m map[string][]string) map[string][]common.Regexp {
+	compiled := make(map[string][]common.Regexp, len(m))
+	for k, v := range m {
+		regexps := make([]common.Regexp, len(v))
+		for i, pattern := range v {
+			re, err := common.NewRegexp(pattern)
+			if err != nil {
+				panic(err)
+			}
+			regexps[i] = re
+		}
+		compiled[k] = regexps
+	}
+	return compiled
 }
 
 func runCustomPropertyTestCase(t *testing.T, prctx pull.Context, cases []customPropertyTestCase) {

--- a/policy/predicate/custom_properties_test.go
+++ b/policy/predicate/custom_properties_test.go
@@ -1,0 +1,337 @@
+// Copyright 2025 Palantir Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package predicate
+
+import (
+	"context"
+	"testing"
+
+	"github.com/palantir/policy-bot/policy/common"
+	"github.com/palantir/policy-bot/pull"
+	"github.com/palantir/policy-bot/pull/pulltest"
+	"github.com/stretchr/testify/assert"
+)
+
+func ptr[T any](v T) *T {
+	return &v
+}
+
+var customPropertiesTestCtx = &pulltest.Context{
+	RepositoryCustomPropertiesValue: map[string]pull.CustomProperty{
+		"custom1": {String: ptr("value1")},
+		"custom2": {String: ptr("value2")},
+		"custom3": {Array: []string{"a", "b", "c"}},
+	},
+}
+
+var defaultTestCustomPropertiesValues = []string{
+	"custom1: value1",
+	"custom2: value2",
+	"custom3: [a, b, c]",
+}
+
+func TestCustomPropertiesIsNotNull(t *testing.T) {
+	runCustomPropertyTestCase(t, customPropertiesTestCtx, []customPropertyTestCase{
+		{
+			description: "property is present and not null",
+			predicate:   CustomPropertyIsNotNull{"custom1", "custom2", "custom3"},
+			ExpectedPredicateResult: &common.PredicateResult{
+				Satisfied:       true,
+				Values:          defaultTestCustomPropertiesValues,
+				ConditionValues: []string{"custom1", "custom2", "custom3"},
+			},
+		},
+		{
+			description: "some properties only are present",
+			predicate:   CustomPropertyIsNotNull{"custom1", "custom2", "custom3", "custom4"},
+			ExpectedPredicateResult: &common.PredicateResult{
+				Satisfied:       false,
+				Values:          defaultTestCustomPropertiesValues,
+				ConditionValues: []string{"custom1", "custom2", "custom3", "custom4"},
+			},
+		},
+		{
+			description: "some properties only are checked",
+			predicate:   CustomPropertyIsNotNull{"custom1", "custom2"},
+			ExpectedPredicateResult: &common.PredicateResult{
+				Satisfied:       true,
+				Values:          defaultTestCustomPropertiesValues,
+				ConditionValues: []string{"custom1", "custom2"},
+			},
+		},
+		{
+			description: "no properties are present",
+			predicate:   CustomPropertyIsNotNull{"custom4", "custom5"},
+			ExpectedPredicateResult: &common.PredicateResult{
+				Satisfied:       false,
+				Values:          defaultTestCustomPropertiesValues,
+				ConditionValues: []string{"custom4", "custom5"},
+			},
+		},
+		{
+			description: "no properties are checked",
+			predicate:   CustomPropertyIsNotNull{},
+			ExpectedPredicateResult: &common.PredicateResult{
+				Satisfied:       true,
+				Values:          defaultTestCustomPropertiesValues,
+				ConditionValues: []string{},
+			},
+		},
+	})
+}
+
+func TestCustomPropertiesIsNull(t *testing.T) {
+	runCustomPropertyTestCase(t, customPropertiesTestCtx, []customPropertyTestCase{
+		{
+			description: "property is present and not null",
+			predicate:   CustomPropertyIsNull{"custom1", "custom2", "custom3"},
+			ExpectedPredicateResult: &common.PredicateResult{
+				Satisfied:       false,
+				Values:          defaultTestCustomPropertiesValues,
+				ConditionValues: []string{"custom1", "custom2", "custom3"},
+			},
+		},
+		{
+			description: "some properties only are present",
+			predicate:   CustomPropertyIsNull{"custom1", "custom2", "custom3", "custom4"},
+			ExpectedPredicateResult: &common.PredicateResult{
+				Satisfied:       false,
+				Values:          defaultTestCustomPropertiesValues,
+				ConditionValues: []string{"custom1", "custom2", "custom3", "custom4"},
+			},
+		},
+		{
+			description: "some properties only are checked",
+			predicate:   CustomPropertyIsNull{"custom1", "custom2"},
+			ExpectedPredicateResult: &common.PredicateResult{
+				Satisfied:       false,
+				Values:          defaultTestCustomPropertiesValues,
+				ConditionValues: []string{"custom1", "custom2"},
+			},
+		},
+		{
+			description: "no properties are present",
+			predicate:   CustomPropertyIsNull{"custom4", "custom5"},
+			ExpectedPredicateResult: &common.PredicateResult{
+				Satisfied:       true,
+				Values:          defaultTestCustomPropertiesValues,
+				ConditionValues: []string{"custom4", "custom5"},
+			},
+		},
+		{
+			description: "no properties are checked",
+			predicate:   CustomPropertyIsNull{},
+			ExpectedPredicateResult: &common.PredicateResult{
+				Satisfied:       true,
+				Values:          defaultTestCustomPropertiesValues,
+				ConditionValues: []string{},
+			},
+		},
+	})
+}
+
+func TestCustomPropertiesMatchesAnyOf(t *testing.T) {
+	runCustomPropertyTestCase(t, customPropertiesTestCtx, []customPropertyTestCase{
+		{
+			description: "property matches regex",
+			predicate:   CustomPropertyMatchesAnyOf{"custom1": []string{`.*`}},
+			ExpectedPredicateResult: &common.PredicateResult{
+				Satisfied:     true,
+				Values:        defaultTestCustomPropertiesValues,
+				ConditionsMap: map[string][]string{"custom1": {`.*`}},
+			},
+		},
+		{
+			description: "property does not match regex",
+			predicate:   CustomPropertyMatchesAnyOf{"custom1": []string{`nomatch`}},
+			ExpectedPredicateResult: &common.PredicateResult{
+				Satisfied:     false,
+				Values:        defaultTestCustomPropertiesValues,
+				ConditionsMap: map[string][]string{"custom1": {`nomatch`}},
+			},
+		},
+		{
+			description: "multiple regexes and one matches",
+			predicate:   CustomPropertyMatchesAnyOf{"custom1": []string{`nomatch`, `value1`}},
+			ExpectedPredicateResult: &common.PredicateResult{
+				Satisfied:     true,
+				Values:        defaultTestCustomPropertiesValues,
+				ConditionsMap: map[string][]string{"custom1": {`nomatch`, `value1`}},
+			},
+		},
+		{
+			description: "multiple regexes and none match",
+			predicate:   CustomPropertyMatchesAnyOf{"custom1": []string{`nomatch`, `alsonomatch`}},
+			ExpectedPredicateResult: &common.PredicateResult{
+				Satisfied:     false,
+				Values:        defaultTestCustomPropertiesValues,
+				ConditionsMap: map[string][]string{"custom1": {`nomatch`, `alsonomatch`}},
+			},
+		},
+		{
+			description: "multiple properties and one matches",
+			predicate:   CustomPropertyMatchesAnyOf{"custom1": []string{`nomatch`}, "custom2": []string{`value2`}},
+			ExpectedPredicateResult: &common.PredicateResult{
+				Satisfied:     false,
+				Values:        defaultTestCustomPropertiesValues,
+				ConditionsMap: map[string][]string{"custom1": {`nomatch`}, "custom2": {`value2`}},
+			},
+		},
+		{
+			description: "multiple properties and none match",
+			predicate:   CustomPropertyMatchesAnyOf{"custom1": []string{`nomatch`}, "custom2": []string{`alsonomatch`}},
+			ExpectedPredicateResult: &common.PredicateResult{
+				Satisfied:     false,
+				Values:        defaultTestCustomPropertiesValues,
+				ConditionsMap: map[string][]string{"custom1": {`nomatch`}, "custom2": {`alsonomatch`}},
+			},
+		},
+		{
+			description: "array should never match",
+			predicate:   CustomPropertyMatchesAnyOf{"custom3": []string{`.*`}},
+			ExpectedPredicateResult: &common.PredicateResult{
+				Satisfied:     false,
+				Values:        defaultTestCustomPropertiesValues,
+				ConditionsMap: map[string][]string{"custom3": {`.*`}},
+			},
+		},
+		{
+			description: "invalid regex should err",
+			predicate:   CustomPropertyMatchesAnyOf{"custom1": []string{`*`}},
+			ExpectedErr: func(err error) bool {
+				return err.Error() == "failed to compile regex * for custom property custom1: error parsing regexp: missing argument to repetition operator: `*`"
+			},
+		},
+		{
+			description: "no properties are checked",
+			predicate:   CustomPropertyMatchesAnyOf{},
+			ExpectedPredicateResult: &common.PredicateResult{
+				Satisfied:     true,
+				Values:        defaultTestCustomPropertiesValues,
+				ConditionsMap: map[string][]string{},
+			},
+		},
+	})
+}
+
+func TestCustomPropertiesMatchesNoneOf(t *testing.T) {
+	runCustomPropertyTestCase(t, customPropertiesTestCtx, []customPropertyTestCase{
+		{
+			description: "property matches regex",
+			predicate:   CustomPropertyMatchesNoneOf{"custom1": []string{`.*`}},
+			ExpectedPredicateResult: &common.PredicateResult{
+				Satisfied:     false,
+				Values:        defaultTestCustomPropertiesValues,
+				ConditionsMap: map[string][]string{"custom1": {`.*`}},
+			},
+		},
+		{
+			description: "property does not match regex",
+			predicate:   CustomPropertyMatchesNoneOf{"custom1": []string{`nomatch`}},
+			ExpectedPredicateResult: &common.PredicateResult{
+				Satisfied:     true,
+				Values:        defaultTestCustomPropertiesValues,
+				ConditionsMap: map[string][]string{"custom1": {`nomatch`}},
+			},
+		},
+		{
+			description: "multiple regexes and one matches",
+			predicate:   CustomPropertyMatchesNoneOf{"custom1": []string{`nomatch`, `value1`}},
+			ExpectedPredicateResult: &common.PredicateResult{
+				Satisfied:     false,
+				Values:        defaultTestCustomPropertiesValues,
+				ConditionsMap: map[string][]string{"custom1": {`nomatch`, `value1`}},
+			},
+		},
+		{
+			description: "multiple regexes and none match",
+			predicate:   CustomPropertyMatchesNoneOf{"custom1": []string{`nomatch`, `alsonomatch`}},
+			ExpectedPredicateResult: &common.PredicateResult{
+				Satisfied:     true,
+				Values:        defaultTestCustomPropertiesValues,
+				ConditionsMap: map[string][]string{"custom1": {`nomatch`, `alsonomatch`}},
+			},
+		},
+		{
+			description: "multiple properties and one matches",
+			predicate:   CustomPropertyMatchesNoneOf{"custom1": []string{`nomatch`}, "custom2": []string{`value2`}},
+			ExpectedPredicateResult: &common.PredicateResult{
+				Satisfied:     false,
+				Values:        defaultTestCustomPropertiesValues,
+				ConditionsMap: map[string][]string{"custom1": {`nomatch`}, "custom2": {`value2`}},
+			},
+		},
+		{
+			description: "multiple properties and none match",
+			predicate:   CustomPropertyMatchesNoneOf{"custom1": []string{`nomatch`}, "custom2": []string{`alsonomatch`}},
+			ExpectedPredicateResult: &common.PredicateResult{
+				Satisfied:     true,
+				Values:        defaultTestCustomPropertiesValues,
+				ConditionsMap: map[string][]string{"custom1": {`nomatch`}, "custom2": {`alsonomatch`}},
+			},
+		},
+		{
+			description: "array should never match",
+			predicate:   CustomPropertyMatchesNoneOf{"custom3": []string{`.*`}},
+			ExpectedPredicateResult: &common.PredicateResult{
+				Satisfied:     true,
+				Values:        defaultTestCustomPropertiesValues,
+				ConditionsMap: map[string][]string{"custom3": {`.*`}},
+			},
+		},
+		{
+			description: "invalid regex should err",
+			predicate:   CustomPropertyMatchesNoneOf{"custom1": []string{`*`}},
+			ExpectedErr: func(err error) bool {
+				return err.Error() == "failed to compile regex * for custom property custom1: error parsing regexp: missing argument to repetition operator: `*`"
+			},
+		},
+		{
+			description: "no properties are checked",
+			predicate:   CustomPropertyMatchesNoneOf{},
+			ExpectedPredicateResult: &common.PredicateResult{
+				Satisfied:     true,
+				Values:        defaultTestCustomPropertiesValues,
+				ConditionsMap: map[string][]string{},
+			},
+		},
+	})
+}
+
+type customPropertyTestCase struct {
+	description             string
+	predicate               Predicate
+	ExpectedPredicateResult *common.PredicateResult
+	ExpectedErr             func(error) bool
+}
+
+func runCustomPropertyTestCase(t *testing.T, prctx pull.Context, cases []customPropertyTestCase) {
+	ctx := context.Background()
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			predicateResult, err := tc.predicate.Evaluate(ctx, prctx)
+			if tc.ExpectedErr != nil {
+				if !assert.Error(t, err, "expected error but got none") {
+					return
+				}
+				if !tc.ExpectedErr(err) {
+					t.Errorf("error did not match expectation: %v", err)
+				}
+			} else if assert.NoError(t, err, "predicate evaluation failed") {
+				assertPredicateResult(t, tc.ExpectedPredicateResult, predicateResult)
+			}
+		})
+	}
+}

--- a/policy/predicate/predicates.go
+++ b/policy/predicate/predicates.go
@@ -49,6 +49,11 @@ type Predicates struct {
 	HasValidSignatures       *HasValidSignatures       `yaml:"has_valid_signatures,omitempty"`
 	HasValidSignaturesBy     *HasValidSignaturesBy     `yaml:"has_valid_signatures_by,omitempty"`
 	HasValidSignaturesByKeys *HasValidSignaturesByKeys `yaml:"has_valid_signatures_by_keys,omitempty"`
+
+	CustomPropertyIsNull        *CustomPropertyIsNull        `yaml:"custom_property_is_null,omitempty"`
+	CustomPropertyIsNotNull     *CustomPropertyIsNotNull     `yaml:"custom_property_is_not_null,omitempty"`
+	CustomPropertyMatchesAnyOf  *CustomPropertyMatchesAnyOf  `yaml:"custom_property_matches_any_of,omitempty"`
+	CustomPropertyMatchesNoneOf *CustomPropertyMatchesNoneOf `yaml:"custom_property_matches_none_of,omitempty"`
 }
 
 func (p Predicates) IsZero() bool {
@@ -138,6 +143,19 @@ func (p *Predicates) Predicates() []Predicate {
 
 	if p.HasValidSignaturesByKeys != nil {
 		ps = append(ps, Predicate(p.HasValidSignaturesByKeys))
+	}
+
+	if p.CustomPropertyIsNotNull != nil {
+		ps = append(ps, Predicate(p.CustomPropertyIsNotNull))
+	}
+	if p.CustomPropertyIsNull != nil {
+		ps = append(ps, Predicate(p.CustomPropertyIsNull))
+	}
+	if p.CustomPropertyMatchesAnyOf != nil {
+		ps = append(ps, Predicate(p.CustomPropertyMatchesAnyOf))
+	}
+	if p.CustomPropertyMatchesNoneOf != nil {
+		ps = append(ps, Predicate(p.CustomPropertyMatchesNoneOf))
 	}
 
 	return ps

--- a/pull/context.go
+++ b/pull/context.go
@@ -55,6 +55,10 @@ type Context interface {
 	// RepositoryName returns the repo that the pull request targets.
 	RepositoryName() string
 
+	// RepositoryCustomProperties returns the custom properties of the repo that the pull request targets.
+	// For an unset property, the key is _not_ present in the map.
+	RepositoryCustomProperties() (map[string]CustomProperty, error)
+
 	// Number returns the number of the pull request.
 	Number() int
 
@@ -255,4 +259,9 @@ type Body struct {
 	CreatedAt    time.Time
 	Author       string
 	LastEditedAt time.Time
+}
+
+type CustomProperty struct {
+	String *string
+	Array  []string
 }

--- a/pull/github.go
+++ b/pull/github.go
@@ -131,19 +131,20 @@ type GitHubContext struct {
 	pr     *v4PullRequest
 
 	// cached fields
-	files         []*File
-	commits       []*Commit
-	comments      []*Comment
-	reviews       []*Review
-	reviewers     []*Reviewer
-	collaborators []*Collaborator
-	permissions   map[string]Permission
-	teams         map[string]Permission
-	membership    map[string]bool
-	statuses      map[string]string
-	labels        []string
-	pushedAt      map[string]time.Time
-	workflowRuns  map[string][]string
+	files                      []*File
+	commits                    []*Commit
+	comments                   []*Comment
+	reviews                    []*Review
+	reviewers                  []*Reviewer
+	collaborators              []*Collaborator
+	permissions                map[string]Permission
+	teams                      map[string]Permission
+	membership                 map[string]bool
+	statuses                   map[string]string
+	labels                     []string
+	pushedAt                   map[string]time.Time
+	workflowRuns               map[string][]string
+	repositoryCustomProperties map[string]CustomProperty
 }
 
 // NewGitHubContext creates a new pull.Context that makes GitHub requests to
@@ -194,6 +195,40 @@ func (ghc *GitHubContext) RepositoryOwner() string {
 
 func (ghc *GitHubContext) RepositoryName() string {
 	return ghc.repo
+}
+
+func (ghc *GitHubContext) RepositoryCustomProperties() (map[string]CustomProperty, error) {
+	if ghc.repositoryCustomProperties == nil {
+		if err := ghc.loadRepositoryCustomProperties(); err != nil {
+			return nil, err
+		}
+	}
+
+	return ghc.repositoryCustomProperties, nil
+}
+
+func (ghc *GitHubContext) loadRepositoryCustomProperties() error {
+	values, _, err := ghc.client.Repositories.GetAllCustomPropertyValues(ghc.ctx, ghc.owner, ghc.repo)
+	if err != nil {
+		return errors.Wrap(err, "failed to load repository custom properties")
+	}
+
+	ghc.repositoryCustomProperties = make(map[string]CustomProperty)
+	for _, value := range values {
+		var result CustomProperty
+		if value.Value == nil {
+			continue
+		} else if strValue, ok := value.Value.(string); ok {
+			result = CustomProperty{String: &strValue}
+		} else if arrValue, ok := value.Value.([]string); ok {
+			result = CustomProperty{Array: arrValue}
+		} else {
+			return errors.Errorf("unexpected type for custom property %s: %T", value.PropertyName, value.Value)
+		}
+		ghc.repositoryCustomProperties[value.PropertyName] = result
+	}
+
+	return nil
 }
 
 func (ghc *GitHubContext) Number() int {

--- a/pull/pulltest/context.go
+++ b/pull/pulltest/context.go
@@ -77,6 +77,9 @@ type Context struct {
 	LabelsValue []string
 	LabelsError error
 
+	RepositoryCustomPropertiesValue map[string]pull.CustomProperty
+	RepositoryCustomPropertiesError error
+
 	Draft bool
 }
 
@@ -263,6 +266,10 @@ func (c *Context) LatestWorkflowRuns() (map[string][]string, error) {
 
 func (c *Context) Labels() ([]string, error) {
 	return c.LabelsValue, c.LabelsError
+}
+
+func (c *Context) RepositoryCustomProperties() (map[string]pull.CustomProperty, error) {
+	return c.RepositoryCustomPropertiesValue, c.RepositoryCustomPropertiesError
 }
 
 // assert that the test object implements the full interface


### PR DESCRIPTION
## What

Implement custom properties predicates with regard to https://github.com/palantir/policy-bot/discussions/1029 and https://github.com/palantir/policy-bot/discussions/1029#discussioncomment-14296382

## Screenshots

Some screenshots when testing the feature to cover the "testing" of `ConditionPhrase` and `ReverseSkipPhrase` that is not covered by `policy/predicate/custom_properties_test.go`

<details><summary>match</summary>
<img width="296" height="604" alt="image" src="https://github.com/user-attachments/assets/ae103817-0b9c-4491-95d5-363046c8f9c8" />
</details>
<details><summary>nomatch</summary>
<img width="294" height="608" alt="image" src="https://github.com/user-attachments/assets/3897189d-059b-4fe4-a4fc-1bcd1a8206fc" />
</details>
<details><summary>empty</summary>
<img width="294" height="424" alt="image" src="https://github.com/user-attachments/assets/0cf95294-ac0d-441d-bef9-02200569a465" />
</details>
